### PR TITLE
shade source/destination same fix

### DIFF
--- a/src/main/java/walkingkooka/gwt/archivemaker/maven/GwtArchiveMakerTool.java
+++ b/src/main/java/walkingkooka/gwt/archivemaker/maven/GwtArchiveMakerTool.java
@@ -324,7 +324,7 @@ public final class GwtArchiveMakerTool {
                                 final String path = f.path();
 
                                 final String base;
-                                if (path.endsWith(".java")) {
+                                if (!fromPackage.equals(toPackage) && path.endsWith(".java")) {
                                     base = superDirectory + "/";
                                 } else {
                                     base = "";


### PR DESCRIPTION
- no longer moves *.java files that are shaded with source=destination under super